### PR TITLE
Update Zigbee identity strings for Sensy-One Z1 sensor

### DIFF
--- a/assets/source/main/esp_zb_light.h
+++ b/assets/source/main/esp_zb_light.h
@@ -23,8 +23,8 @@
 #define ESP_ZB_PRIMARY_CHANNEL_MASK       ESP_ZB_TRANSCEIVER_ALL_CHANNELS_MASK  /* Zigbee primary channel mask use in the example */
 
 /* Basic manufacturer information */
-#define ESP_MANUFACTURER_NAME "\x09""ESPRESSIF"      /* Customized manufacturer name */
-#define ESP_MODEL_IDENTIFIER "\x07"CONFIG_IDF_TARGET /* Customized model identifier */
+#define ESP_MANUFACTURER_NAME "\x09""Sensy-One"      /* Customized manufacturer name */
+#define ESP_MODEL_IDENTIFIER "\x10""Z1 mmWave Sensor" /* Customized model identifier */
 
 #define ESP_ZB_ZR_CONFIG()                                                              \
     {                                                                                   \


### PR DESCRIPTION
## Summary
- update the Zigbee Basic cluster manufacturer string to report "Sensy-One"
- change the model identifier to "Z1 mmWave Sensor" so Home Assistant shows the proper device name

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d63fd68700832a8174f640b27689b7